### PR TITLE
PaymentRequest: catch promise errors

### DIFF
--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -442,7 +442,7 @@ export default class PaymentRequest {
       const normalizedDetails = convertDetailAmountsToString(this._details);
       const options = this._options;
 
-      return NativePayments.show(platformMethodData, normalizedDetails, options);
+      NativePayments.show(platformMethodData, normalizedDetails, options).catch(reject);
     });
 
     return this._acceptPromise;

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-payments",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",
     "run:ios": "cd examples/native && yarn run:ios",


### PR DESCRIPTION
Since the promise executor return value is ignore according to the
JS spec, the promise returned by NativePayments.show() must
be treated. This was causing the PaymentRequest.show() promise
to never be rejected in some cases, which would lead in a
inifinite waiting.